### PR TITLE
Hash passwords in database for security

### DIFF
--- a/server/src/api/account.py
+++ b/server/src/api/account.py
@@ -68,7 +68,7 @@ class AccountApi(object):
         password = JSON_object.get("password")
 
         try:
-            isLoggedIn = self.database.get_password(username) == password
+            isLoggedIn = self.database.password_is_correct(username, password)
             cherrypy.session["username"] = username
             cherrypy.session["password"] = password
 

--- a/server/src/api/pay_exec.py
+++ b/server/src/api/pay_exec.py
@@ -43,7 +43,7 @@ class PayExecApi(object):
             #checking if user is logged in successfully
             username = cherrypy.session["username"]
             password = cherrypy.session["password"]
-            isLoggedIn = self.database.get_password(username) == password
+            isLoggedIn = self.database.password_is_correct(username, password)
 
             if (isLoggedIn == True):
                 #make payment if user is Logged in

--- a/server/test_db.py
+++ b/server/test_db.py
@@ -11,7 +11,7 @@ class TestDatabaseMethods(unittest.TestCase):
         test_db = DatabaseManager()
         test_db.init_db("test.db")
         test_db.add_user("bob", "bobiscool1")
-        self.assertEqual(test_db.get_password("bob"), "bobiscool1")
+        self.assertTrue(test_db.password_is_correct("bob", "bobiscool1"))
         test_db.delete_db()
 
     def test_add_duplicate_user(self):


### PR DESCRIPTION
Passwords are no longer stored in plaintext increasing security.

Closes #124 

**Description**

- Altered database schema to add columns for password hash and salt 
- Passwords are now hashed + salted before storing in the database
- Instead of directly comparing passwords, implemented a function to test if the password is correct by testing if the hash is correct
- Added migration so that if a database exists with plaintext passwords, passwords will be hashed automatically without additional action required from the user 

**Testing**

Tested logging in and logging out using the web UI, tested creating an account, tested migration from existing database; updated and ran test_db unit test script to ensure database is working correctly.

**Checklist**
<!-- this section may be replaced with GitHub action checks later -->
- [x] I have tested my change
- [x] Code builds successfully and all tests pass
- [x] Docs have been added/updated if needed -- will update docs on database schema when PR approved, there are no other important changes to documentation that I can see
